### PR TITLE
Add group_aeroo_manager to group_system

### DIFF
--- a/report_aeroo/security/security.xml
+++ b/report_aeroo/security/security.xml
@@ -5,4 +5,8 @@
         <field name="name">Aeroo Manager</field>
     </record>
 
+    <record id="base.group_system" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('group_aeroo_manager'))]"/>
+    </record>
+
 </odoo>


### PR DESCRIPTION
When adding the system group to a user, he has access to the menu option for aeroo reports. If we forget to add the aeroo report, the user can not access the list view.

https://pgi.numigi.org/web#id=1283&view_type=form&model=project.task&action=292&active_id=38&menu_id=200
