### PR TITLE
Fix the lang of object being printed in an aeroo report

### DIFF
--- a/report_aeroo/models/ir_actions_report.py
+++ b/report_aeroo/models/ir_actions_report.py
@@ -209,7 +209,6 @@ class IrActionsReport(models.Model):
 
         record = self.env[self.model].browse(doc_ids[0])
 
-        current_report_data = dict(data, o=record)
         report_lang = self._get_aeroo_lang(record)
         report_timezone = self._get_aeroo_timezone(record)
         self = self.with_context(lang=report_lang, tz=report_timezone)
@@ -222,6 +221,8 @@ class IrActionsReport(models.Model):
         template = self._get_aeroo_template(record)
 
         # Render the report
+        current_report_data = dict(
+            data, o=record.with_context(lang=report_lang, tz=report_timezone))
         output = self._render_aeroo(template, current_report_data, output_format)
 
         # Generate the attachment


### PR DESCRIPTION
https://isidor.numigi.net/web#id=5894&view_type=form&model=project.task&action=292&active_id=41&menu_id=200

@foutoucour désolé, très difficile d'ajouter des tests pour cette ligne de code. Il faudrait que j'imprime un rapport dans une langue avec un champs traduisible, que j'ouvre l'archive odt et que je vérifie que le champ traduit se trouve dans le fichier xml du odt.