### PR TITLE
Aeroo checks: fix case where credit notes are reconciled before.

### DIFF
--- a/account_check_printing_aeroo/print_stub_lines.py
+++ b/account_check_printing_aeroo/print_stub_lines.py
@@ -4,6 +4,63 @@
 from odoo import models
 
 
+def _get_reconcile_sum(account_move_reconciles: models.Model, use_company_currency: bool) -> float:
+    """Get the sum of amounts of the given account move reconciles.
+
+    :param account_move_reconciles: the reconciles to sum
+    :param use_company_currency: whether to return the amount in company currency.
+    :return: the sum of amounts
+    """
+    amount_field = 'amount' if use_company_currency else 'amount_currency'
+    return sum(account_move_reconciles.mapped(amount_field))
+
+
+def _get_invoice_paid_amount(check: models.Model, invoice: models.Model) -> float:
+    """Get the amount paid on the invoice.
+
+    The result amount includes any refunds already applied to the invoice,
+    plus the amount paid with the given payment (check).
+
+    If the invoice has a foreign currency, the amount in the foreign
+    currency is returned. This implies that the payment is in the same
+    currency than the invoice.
+
+    :param check: the check payment.
+    :param invoice: the invoice for which to determine the amount paid.
+    :return: the amount paid.
+    """
+    refund_reconciles = (
+        invoice.move_id.line_ids.mapped('matched_debit_ids')
+        .filtered(lambda r: r.debit_move_id.invoice_id)
+    )
+    payment_reconciles = (
+        invoice.move_id.line_ids.mapped('matched_debit_ids')
+        .filtered(lambda r: r.debit_move_id in check.move_line_ids)
+    )
+
+    in_company_currency = invoice.currency_id == invoice.company_id.currency_id
+    return _get_reconcile_sum(refund_reconciles | payment_reconciles, in_company_currency)
+
+
+def _get_refund_paid_amount(check: models.Model, refund: models.Model) -> float:
+    """Get the paid amount to display on the stub for a refund.
+
+    For a refund, the paid amount is the total of amounts reconciled
+    with any invoice paid by the check.
+
+    :param check: the check payment.
+    :param refund: the refund for which to determine the amount paid.
+    :return: the amount paid.
+    """
+    invoice_reconciles = (
+        refund.move_id.line_ids.mapped('matched_credit_ids')
+        .filtered(lambda r: r.credit_move_id.invoice_id in check.invoice_ids)
+    )
+
+    in_company_currency = refund.currency_id == refund.company_id.currency_id
+    return _get_reconcile_sum(invoice_reconciles, in_company_currency)
+
+
 class AccountPaymentWithCheckStubLines(models.Model):
     """Enable getting the stub line details from an aeroo report.
 
@@ -14,12 +71,19 @@ class AccountPaymentWithCheckStubLines(models.Model):
     _inherit = "account.payment"
 
     def get_aeroo_check_stub_lines(self):
-        """Method callable from the aeroo report."""
-        invoices_and_credit_notes = (
+        """Get the data to display on the check stub lines.
+
+        It contains one line per invoice and one line per refund matched with
+        any of the invoices.
+
+        :return: the check stub lines data.
+        :rtype: List[dict]
+        """
+        invoices_and_refunds = (
             self.invoice_ids |
             self.invoice_ids.mapped('payment_move_line_ids.invoice_id')
         ).sorted(key=lambda inv: inv.date_due)
-        return [self._aeroo_check_make_stub_line(inv) for inv in invoices_and_credit_notes]
+        return [self._aeroo_check_make_stub_line(inv) for inv in invoices_and_refunds]
 
     def _aeroo_check_make_stub_line(self, invoice):
         """Return the dict used to display an invoice/refund in the stub.
@@ -31,31 +95,23 @@ class AccountPaymentWithCheckStubLines(models.Model):
             * work with invoices paid in different currencies.
             * work with invoices and refunds in the same payment.
             * display paid amounts in the currency of the invoice.
-        """
-        if invoice.type in ['in_invoice', 'out_refund']:
-            invoice_sign = 1
-            invoice_payment_reconcile = (
-                invoice.move_id.line_ids.mapped('matched_debit_ids')
-                .filtered(lambda r: r.debit_move_id in self.move_line_ids or
-                          r.debit_move_id.invoice_id)
-            )
-        else:
-            invoice_sign = -1
-            invoice_payment_reconcile = (
-                invoice.move_id.line_ids.mapped('matched_credit_ids')
-                .filtered(lambda r: r.credit_move_id in self.move_line_ids or
-                          r.credit_move_id.invoice_id)
-            )
 
-        if invoice.currency_id != self.journal_id.company_id.currency_id:
-            amount_paid = abs(sum(invoice_payment_reconcile.mapped('amount_currency')))
-        else:
-            amount_paid = abs(sum(invoice_payment_reconcile.mapped('amount')))
+        Note here that a customer refund is handled like a supplier invoice
+        and a customer invoice is handled like a supplier refund.
+        """
+        is_supplier_invoice = invoice.type in ('in_invoice', 'out_refund')
+
+        amount_paid = (
+            _get_invoice_paid_amount(self, invoice) if is_supplier_invoice
+            else _get_refund_paid_amount(self, invoice)
+        )
+
+        amount_sign = 1 if is_supplier_invoice else -1
 
         return {
             'invoice': invoice,
-            'amount_total': invoice_sign * invoice.amount_total,
-            'amount_residual': invoice_sign * invoice.residual,
-            'amount_paid': invoice_sign * amount_paid,
+            'amount_total': amount_sign * invoice.amount_total,
+            'amount_residual': amount_sign * invoice.residual,
+            'amount_paid': amount_sign * amount_paid,
             'currency': invoice.currency_id,
         }

--- a/account_check_printing_aeroo/print_stub_lines.py
+++ b/account_check_printing_aeroo/print_stub_lines.py
@@ -37,14 +37,14 @@ class AccountPaymentWithCheckStubLines(models.Model):
             invoice_payment_reconcile = (
                 invoice.move_id.line_ids.mapped('matched_debit_ids')
                 .filtered(lambda r: r.debit_move_id in self.move_line_ids or
-                          r.debit_move_id.invoice_id in self.invoice_ids)
+                          r.debit_move_id.invoice_id)
             )
         else:
             invoice_sign = -1
             invoice_payment_reconcile = (
                 invoice.move_id.line_ids.mapped('matched_credit_ids')
                 .filtered(lambda r: r.credit_move_id in self.move_line_ids or
-                          r.credit_move_id.invoice_id in self.invoice_ids)
+                          r.credit_move_id.invoice_id)
             )
 
         if invoice.currency_id != self.journal_id.company_id.currency_id:

--- a/account_check_printing_aeroo/tests/test_print_stub_lines.py
+++ b/account_check_printing_aeroo/tests/test_print_stub_lines.py
@@ -2,6 +2,7 @@
 # © 2018 Numigi (tm) and all its contributors (https://bit.ly/numigiens)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import random
 from datetime import datetime, timedelta
 from odoo.tests import common
 
@@ -38,73 +39,65 @@ class TestCheckPrintStubLines(common.SavepointCase):
             'type': 'bank',
         })
 
-    def _create_invoices(self, currency):
-        """Create 4 payable invoices.
-
-        * 3 invoices of 100
-        * 1 refund of -240
-        """
-        invoices = self.env['account.invoice']
-
-        journal = self.env['account.journal'].create({
+        cls.purchase_journal = cls.env['account.journal'].create({
             'name': 'PURCHASES',
-            'code': 'PURC',
+            'code': 'PURC1',
             'type': 'purchase',
-            'currency_id':
-            currency.id if currency != self.company_currency else None,
         })
 
-        account = self.env['account.account'].create({
-            'user_type_id':
-            self.env.ref('account.data_account_type_payable').id,
+        cls.payable_account = cls.env['account.account'].create({
+            'user_type_id': cls.env.ref('account.data_account_type_payable').id,
             'name': 'Account Payable',
-            'code': '210X00',
-            'currency_id':
-            currency.id if currency != self.company_currency else None,
+            'code': '210100',
             'reconcile': True,
         })
 
-        for i in range(1, 4):
-            invoices |= self.env['account.invoice'].create({
-                'partner_id': self.partner.id,
-                'journal_id': journal.id,
-                'account_id': account.id,
-                'date': datetime.now(),
-                'date_due': datetime.now() + timedelta(i),
-                'type': 'in_invoice',
-                'reference': 'XXXXXX%s' % i,
-                'currency_id': currency.id,
-                'invoice_line_ids': [
-                    (0, 0, {
-                        'name': 'My Product',
-                        'quantity': 1,
-                        'price_unit': 100,
-                        'account_id': self.expense_account.id,
-                    })
-                ]
-            })
+        cls.purchase_journal_foreign = cls.env['account.journal'].create({
+            'name': 'PURCHASES',
+            'code': 'PURC2',
+            'type': 'purchase',
+            'currency_id': cls.foreign_currency.id,
+        })
 
-        invoices |= self.env['account.invoice'].create({
+        cls.payable_account_foreign = cls.env['account.account'].create({
+            'user_type_id': cls.env.ref('account.data_account_type_payable').id,
+            'name': 'Account Payable',
+            'code': '210200',
+            'currency_id': cls.foreign_currency.id,
+            'reconcile': True,
+        })
+
+    def _create_invoice(self, amount, currency, days_before_due_date, type_='in_invoice'):
+        """Create payable invoice in the given currency."""
+        journal = (
+            self.purchase_journal
+            if currency == self.company_currency else self.purchase_journal_foreign
+        )
+        account = (
+            self.payable_account
+            if currency == self.company_currency else self.payable_account_foreign
+        )
+        invoice = self.env['account.invoice'].create({
             'partner_id': self.partner.id,
             'journal_id': journal.id,
             'account_id': account.id,
             'date': datetime.now(),
-            'date_due': datetime.now() + timedelta(4),
-            'type': 'in_refund',
-            'reference': 'XXXXXX%s' % 4,
+            'date_due': datetime.now() + timedelta(days_before_due_date),
+            'type': type_,
+            'reference': 'INV%d' % random.randrange(1, 10000),
             'currency_id': currency.id,
             'invoice_line_ids': [
                 (0, 0, {
-                    'name': 'Refund Line',
+                    'name': 'My Product',
                     'quantity': 1,
-                    'price_unit': 240,
+                    'price_unit': amount,
                     'account_id': self.expense_account.id,
                 })
             ]
         })
 
-        invoices.action_invoice_open()
-        return invoices
+        invoice.action_invoice_open()
+        return invoice
 
     def _create_payment(self, invoices, currency, amount):
         """Create a payment for the given invoices.
@@ -120,71 +113,113 @@ class TestCheckPrintStubLines(common.SavepointCase):
             'currency_id': currency.id,
             'payment_method_id': self.env.ref(
                 'account_check_printing.account_payment_method_check').id,
-            'invoice_ids': [(6, 0, invoices.ids)],
+            'invoice_ids': [(6, 0, [inv.id for inv in invoices])],
             'partner_type': 'supplier',
             'payment_type': 'outbound',
         })
         payment.post()
         return payment
 
-    def _check_stub_lines(self, lines, invoices):
-        """Check the amounts in the stub lines.
-
-        The result of the stub is the same whether or not the invoices and
-        payments are in the same currency. The logic to get these amounts
-        is however different.
-        """
-        self.assertEqual(lines, [
-            {
-                'amount_paid': 100,
-                'amount_residual': 0,
-                'amount_total': 100,
-                'currency': invoices[0].currency_id,
-                'invoice': invoices[0],
-            },
-            {
-                'amount_paid': 100,
-                'amount_residual': 0,
-                'amount_total': 100,
-                'currency': invoices[1].currency_id,
-                'invoice': invoices[1],
-            },
-            {
-                'amount_paid': 100,
-                'amount_residual': 0,
-                'amount_total': 100,
-                'currency': invoices[2].currency_id,
-                'invoice': invoices[2],
-            },
-            {
-                'amount_paid': -240,
-                'amount_residual': -0,
-                'amount_total': -240,
-                'currency': invoices[3].currency_id,
-                'invoice': invoices[3],
-            }
-        ])
+    def _check_stub_line(self, line, invoice, amount_total, amount_paid, amount_residual):
+        """Check the amount in the given stub line."""
+        self.assertEqual(line, {
+            'amount_total': amount_total,
+            'amount_paid': amount_paid,
+            'amount_residual': amount_residual,
+            'currency': invoice.currency_id,
+            'invoice': invoice,
+        })
 
     def test_payment_and_invoices_both_in_company_currency(self):
-        invoices = self._create_invoices(self.company_currency)
+        invoices = [
+            self._create_invoice(100, self.company_currency, 1, type_='in_invoice'),
+            self._create_invoice(100, self.company_currency, 2, type_='in_invoice'),
+            self._create_invoice(100, self.company_currency, 3, type_='in_invoice'),
+            self._create_invoice(240, self.company_currency, 4, type_='in_refund'),
+        ]
         payment = self._create_payment(invoices, self.company_currency, 60)
         lines = payment.get_aeroo_check_stub_lines()
-        self._check_stub_lines(lines, invoices)
+        assert len(lines) == 4
+        self._check_stub_line(lines[0], invoices[0], 100, 100, 0)
+        self._check_stub_line(lines[1], invoices[1], 100, 100, 0)
+        self._check_stub_line(lines[2], invoices[2], 100, 100, 0)
+        self._check_stub_line(lines[3], invoices[3], -240, -240, 0)
 
     def test_payment_and_invoices_both_in_foreign_currency(self):
-        invoices = self._create_invoices(self.foreign_currency)
+        invoices = [
+            self._create_invoice(100, self.foreign_currency, 1, type_='in_invoice'),
+            self._create_invoice(100, self.foreign_currency, 2, type_='in_invoice'),
+            self._create_invoice(100, self.foreign_currency, 3, type_='in_invoice'),
+            self._create_invoice(240, self.foreign_currency, 4, type_='in_refund'),
+        ]
         payment = self._create_payment(invoices, self.foreign_currency, 60)
         lines = payment.get_aeroo_check_stub_lines()
-        self._check_stub_lines(lines, invoices)
+        assert len(lines) == 4
+        self._check_stub_line(lines[0], invoices[0], 100, 100, 0)
+        self._check_stub_line(lines[1], invoices[1], 100, 100, 0)
+        self._check_stub_line(lines[2], invoices[2], 100, 100, 0)
+        self._check_stub_line(lines[3], invoices[3], -240, -240, 0)
 
     def test_payment_in_foreign_currency(self):
-        invoices = self._create_invoices(self.company_currency)
+        invoices = [
+            self._create_invoice(100, self.company_currency, 1, type_='in_invoice'),
+            self._create_invoice(100, self.company_currency, 2, type_='in_invoice'),
+            self._create_invoice(100, self.company_currency, 3, type_='in_invoice'),
+            self._create_invoice(240, self.company_currency, 4, type_='in_refund'),
+        ]
         payment = self._create_payment(invoices, self.foreign_currency, 48)  # 60 * 0.80
         lines = payment.get_aeroo_check_stub_lines()
-        self._check_stub_lines(lines, invoices)
+        assert len(lines) == 4
+        self._check_stub_line(lines[0], invoices[0], 100, 100, 0)
+        self._check_stub_line(lines[1], invoices[1], 100, 100, 0)
+        self._check_stub_line(lines[2], invoices[2], 100, 100, 0)
+        self._check_stub_line(lines[3], invoices[3], -240, -240, 0)
 
     def test_invoices_in_foreign_currency(self):
-        invoices = self._create_invoices(self.foreign_currency)
+        invoices = [
+            self._create_invoice(100, self.foreign_currency, 1, type_='in_invoice'),
+            self._create_invoice(100, self.foreign_currency, 2, type_='in_invoice'),
+            self._create_invoice(100, self.foreign_currency, 3, type_='in_invoice'),
+            self._create_invoice(240, self.foreign_currency, 4, type_='in_refund'),
+        ]
         payment = self._create_payment(invoices, self.company_currency, 75)  # 60 / 0.80
         lines = payment.get_aeroo_check_stub_lines()
-        self._check_stub_lines(lines, invoices)
+        assert len(lines) == 4
+        self._check_stub_line(lines[0], invoices[0], 100, 100, 0)
+        self._check_stub_line(lines[1], invoices[1], 100, 100, 0)
+        self._check_stub_line(lines[2], invoices[2], 100, 100, 0)
+        self._check_stub_line(lines[3], invoices[3], -240, -240, 0)
+
+    def test_ifInvoicesReconciledWithCreditNote_thenCreditNoteStillAppears(self):
+        """If credit note reconciled with invoices, credit note appears on the check.
+
+        This case is the most common in practice.
+
+            1. The refunds have been reconciled with the invoice before being selected
+                on the payment.
+            2. The invoices are selected without the credit for payment.
+            3. The paid amount on the invoices include the credit note amount.
+            4. The credit note appears after the invoices.
+
+        The result is the same as when selecting the invoices and the refunds together
+        for payment.
+        """
+        invoices = [
+            self._create_invoice(100, self.company_currency, 1, type_='in_invoice'),
+            self._create_invoice(100, self.company_currency, 2, type_='in_invoice'),
+        ]
+        refund = self._create_invoice(50, self.company_currency, 3, type_='in_refund')
+
+        # 1. Reconcile the refund with the invoices.
+        refund_move_line = refund.move_id.line_ids.filtered(
+            lambda l: l.account_id == self.payable_account)
+        invoices[0].assign_outstanding_credit(refund_move_line.id)
+
+        # 2. Pay the invoices without the refunds.
+        payment = self._create_payment(invoices, self.company_currency, 150)
+
+        lines = payment.get_aeroo_check_stub_lines()
+        assert len(lines) == 3
+        self._check_stub_line(lines[0], invoices[0], 100, 100, 0)
+        self._check_stub_line(lines[1], invoices[1], 100, 100, 0)
+        self._check_stub_line(lines[2], refund, -50, -50, 0)


### PR DESCRIPTION
Fix the case where the refund is reconciled with the invoice before the payment.

@foutoucour j'ai pensé à ce problème entre temps depuis hier.

Les 4 premiers tests n'ont pas été modifiés. Je les ai juste rendu plus explicites.