### PR TITLE
TA#31827 add company to aeroo context

### DIFF
--- a/report_aeroo/models/ir_actions_report.py
+++ b/report_aeroo/models/ir_actions_report.py
@@ -232,6 +232,7 @@ class IrActionsReport(models.Model):
             'tz': self._get_aeroo_timezone(record),
             'country': self._get_aeroo_country(record),
             'currency': self._get_aeroo_currency(record),
+            'company': self._get_aeroo_company(record),
         }
 
     def _get_aeroo_libreoffice_timeout(self):


### PR DESCRIPTION
This variable was previously used only to select the template to render the report.
Now it will also be available at the rendering.