### PR TITLE
TA#37820 prevent report binary data in field views metadata

### DIFF
--- a/report_aeroo/models/ir_actions_report.py
+++ b/report_aeroo/models/ir_actions_report.py
@@ -117,6 +117,12 @@ class IrActionsReport(models.Model):
         res["id"] = self.id
         return res
 
+    def read(self, fields=None, load='_classic_read'):
+        if not fields:
+            fields = [k for k, v in self._fields.items() if v.type != "binary"]
+
+        return super().read(fields, load)
+
     def _get_aeroo_template(self, record):
         """Get an aeroo template for the given record.
 

--- a/report_aeroo/tests/test_load_views.py
+++ b/report_aeroo/tests/test_load_views.py
@@ -1,0 +1,12 @@
+# © 2018 Numigi (tm) and all its contributors (https://bit.ly/numigiens)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestLoadViews(common.TransactionCase):
+    def test_aeroo_template_data_not_in_result(self):
+        self.env.ref("report_aeroo.aeroo_sample_report").create_action()
+        result = self.env["res.partner"].load_views([(None, "tree")], {"toolbar": True})
+        actions = result["fields_views"]["tree"]["toolbar"]["print"]
+        assert "aeroo_template_data" not in actions[0]


### PR DESCRIPTION
Otherwise, the content of aeroo reports is loaded to the web interface.
This makes the views significantly longer to load and sometimes even
disconnects the user because of timeouts.